### PR TITLE
Bump Kustomize version to 4.5.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,14 @@
 FROM alpine:latest
+
+ENV KUSTOMIZE_VERSION=v4.5.7
+ENV KUSTOMIZE_CHECKSUM="701e3c4bfa14e4c520d481fdf7131f902531bfc002cb5062dcf31263a09c70c9"
+
 RUN adduser kustomize -D \
   && apk add curl git openssh \
   && git config --global url.ssh://git@github.com/.insteadOf https://github.com/
-RUN  curl -L --output /tmp/kustomize_v3.3.0_linux_amd64.tar.gz https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.3.0/kustomize_v3.3.0_linux_amd64.tar.gz \
-  && echo "4b49e1bbdb09851f11bb81081bfffddc7d4ad5f99b4be7ef378f6e3cf98d42b6  /tmp/kustomize_v3.3.0_linux_amd64.tar.gz" | sha256sum -c \
-  && tar -xvzf /tmp/kustomize_v3.3.0_linux_amd64.tar.gz -C /usr/local/bin \
+RUN  curl -L --output /tmp/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz \
+  && echo "${KUSTOMIZE_CHECKSUM}  /tmp/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz" | sha256sum -c \
+  && tar -xvzf /tmp/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz -C /usr/local/bin \
   && chmod +x /usr/local/bin/kustomize \
   && mkdir ~/.ssh \
   && ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts


### PR DESCRIPTION
This hook currently uses kustomize version 3.3.0, which is a full major version behind the current release. As such, it's missing features that are present in the latest release, like the ability to use remote urls in a build. This Pull Request does two things:

- Bumps version to 4.5.7 (current latest) with the correct checksum for that version
- Moves the version & checksum into environmental variable to make it easier to update in the future

### Test Steps:
1. Docker Build Succeeds
```
[+] Building 1.1s (8/8) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                                                                                                                 0.0s
 => => transferring dockerfile: 891B                                                                                                                                                                                                                                                                                                                                 0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                                                                                                                                    0.0s
 => => transferring context: 2B                                                                                                                                                                                                                                                                                                                                      0.0s
 => [internal] load metadata for docker.io/library/alpine:latest                                                                                                                                                                                                                                                                                                     1.0s
 => [1/4] FROM docker.io/library/alpine:latest@sha256:bc41182d7ef5ffc53a40b044e725193bc10142a1243f395ee852a8d9730fc2ad                                                                                                                                                                                                                                               0.0s
 => CACHED [2/4] RUN adduser kustomize -D   && apk add curl git openssh   && git config --global url.ssh://git@github.com/.insteadOf https://github.com/                                                                                                                                                                                                             0.0s
 => CACHED [3/4] RUN  curl -L --output /tmp/kustomize_v4.5.7_linux_amd64.tar.gz https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv4.5.7/kustomize_v4.5.7_linux_amd64.tar.gz   && echo "701e3c4bfa14e4c520d481fdf7131f902531bfc002cb5062dcf31263a09c70c9  /tmp/kustomize_v4.5.7_linux_amd64.tar.gz" | sha256sum -c   && tar -xvzf /tmp/kus  0.0s
 => CACHED [4/4] WORKDIR /src                                                                                                                                                                                                                                                                                                                                        0.0s
 => exporting to image                                                                                                                                                                                                                                                                                                                                               0.0s
 => => exporting layers                                                                                                                                                                                                                                                                                                                                              0.0s
 => => writing image sha256:26ea5a826cc8039dbe1456a9c159dd9c65f93f2e9c8ffb94fadd85aa3484208b
 ```
 
 2.  A repository using remote urls & my fork of this pre-commit hook is able to successfully run
 ```bash
 ~/home-cluster ❯❯❯ pre-commit run
[INFO] Initializing environment for https://github.com/rtrox/pre-commit-docker-kustomize.
[INFO] Installing environment for https://github.com/rtrox/pre-commit-docker-kustomize.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
kustomize-crds...........................................................Passed
kustomize-sources........................................................Passed
kustomize-x86-system.....................................................Passed
kustomize-x86-infra......................................................Passed
```

Config used:
```
---
fail_fast: false
repos:
  - repo: https://github.com/rtrox/pre-commit-docker-kustomize
    rev: 572c9bc
    hooks:
    -   id: kustomize
        name: kustomize-crds
        args: [cluster-cd/crds]
        verbose: false
    -   id: kustomize
        name: kustomize-sources
        args: [cluster-cd/sources]
        verbose: false
    -   id: kustomize
        name: kustomize-x86-system
        args: [cluster-cd/system/x86]
        verbose: false
    -   id: kustomize
        name: kustomize-x86-infra
        args: [cluster-cd/infra/x86]
        verbose: false
 ```
